### PR TITLE
FIX: Belong is not required in Equipt API now

### DIFF
--- a/src/api/controllers/equipt/create.js
+++ b/src/api/controllers/equipt/create.js
@@ -10,8 +10,7 @@ module.exports = {
   inputs: {
     name: { type: 'string', required: true },  // -器材名稱/型號	
     cat: { type: 'number', required: true },  // 分類索引ID		
-    belong: { type: 'number', required: true }, // 創立者ID
-    access: { type: 'number', required: true },  // 存取權限
+    access: {type: 'number', required: true},
     description: { type: 'string', required: true },  // 器材介紹
     price	: { type: 'number', required: true },  // 日租價
     brand	: { type: 'number', required: true },  // 器材品牌名稱
@@ -38,12 +37,12 @@ module.exports = {
 
 
   fn: async function (inputs,exits) {
-    
+    let belong = this.req.session.user.id;
     // 新增資料
     const _create = await Equipt.create({
       name: inputs.name,
       cat: inputs.cat,
-      belong: inputs.belong,
+      belong: belong,
       access: inputs.access,
       photo: inputs.photo,
       description: inputs.description,

--- a/src/config/security.js
+++ b/src/config/security.js
@@ -39,7 +39,7 @@ module.exports.security = {
       'http://127.0.0.1',
       'http://localhost',
       'http://localhost:8080',
-      'http://localhost:3000',
+      'https://localhost.com:3000',
       'https://rental.mdcstudio.tw:3000',
       'https://rental.mdcstudio.tw:8080',
       'https://rental.mdcstudio.tw',


### PR DESCRIPTION
本週小進度
器材Equipt不需要再由前端指出誰擁有，自動由新增的帳號獲取資訊